### PR TITLE
ci(oss): enable embed-images — verify inline diff images in PR comment

### DIFF
--- a/.github/workflows/playwright-oss.yml
+++ b/.github/workflows/playwright-oss.yml
@@ -80,3 +80,4 @@ jobs:
           report-dir: visual-report
           upload-artifact: true
           artifact-retention-days: 30
+          embed-images: true  # uploads baseline/current/diff PNGs and embeds them in the PR comment


### PR DESCRIPTION
## Purpose

Verification PR for `mcbuddy/testivai-oss@v1` v1.0.2 image embedding feature.

Adds `embed-images: true` to the OSS workflow step. Changed snapshots should now show a **baseline / current / diff image table** inline in the PR comment below — no artifact download needed.

Expected PR comment shape:

```
▼ oss-buttons — X.XX% different

  | Baseline | Current | Diff |
  |:---:|:---:|:---:|
  | [screenshot] | [screenshot] | [diff overlay] |

  npx testivai approve "oss-buttons"
```

Note: baselines were captured locally (macOS) so Ubuntu CI will show rendering diffs (~platform font differences). The images will show that clearly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)