### PR TITLE
ci(oss): add /testivai approve command to OSS workflow

### DIFF
--- a/.github/workflows/playwright-oss.yml
+++ b/.github/workflows/playwright-oss.yml
@@ -2,12 +2,16 @@ name: OSS Visual Regression
 
 # Runs the TestivAI OSS lane: local-mode visual regression with no API key.
 #
-# Flow:
-#   1. Install @testivai/witness-playwright (published npm package)
-#   2. Run tests — compares screenshots against committed baselines in
-#      .testivai/baselines/; generates visual-report/ with results.json + index.html
-#   3. Upload the report as a workflow artifact (download from Actions tab)
-#   4. Use mcbuddy/testivai-oss@v1 to post a PR comment and set commit status
+# Two jobs:
+#
+#   oss-visual       — Runs on every PR push. Captures screenshots, diffs against
+#                      committed baselines, uploads the report artifact, and posts
+#                      a PR comment with the diff summary + commit status.
+#
+#   approve-baselines — Runs when a collaborator comments /testivai approve on the PR.
+#                      Downloads the artifact, copies approved screenshots into
+#                      .testivai/baselines/, commits them to the PR branch, and
+#                      posts a confirmation comment. CI re-runs automatically.
 #
 # Baselines are committed to the repo under .testivai/baselines/.
 # To approve changed/new baselines locally after reviewing the report:
@@ -31,19 +35,24 @@ on:
       - '.github/workflows/playwright-oss.yml'
   pull_request:
     branches: [main]
+  issue_comment:
+    types: [created]    # listens for /testivai approve commands
 
 concurrency:
   group: oss-visual-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
-  contents: read
+  contents: write       # approve action commits updated baselines to the branch
   pull-requests: write  # post diff comment on PRs
   statuses: write       # set commit status (pass/fail indicator on the PR)
 
 jobs:
+
+  # ── Runs on every PR push ────────────────────────────────────────────────────
   oss-visual:
     name: Visual Regression (OSS)
+    if: github.event_name != 'issue_comment'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -80,3 +89,17 @@ jobs:
           report-dir: visual-report
           upload-artifact: true
           artifact-retention-days: 30
+
+  # ── Runs when a collaborator comments /testivai approve on the PR ─────────────
+  approve-baselines:
+    name: Approve Baselines
+    if: |
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request != null &&
+      startsWith(github.event.comment.body, '/testivai')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: mcbuddy/testivai-oss/approve@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Adds `issue_comment` trigger so the workflow fires on PR comments
- Upgrades `contents: read` → `contents: write` (required for the approver to commit baselines back to the PR branch)
- Adds `approve-baselines` job using `mcbuddy/testivai-oss/approve@v1`
- Guards `oss-visual` with `if: github.event_name != 'issue_comment'` so it only runs on push/PR events

## How to approve baselines

After CI posts the visual diff comment on your PR, review the report, then comment:

| Comment | Effect |
|---|---|
| `/testivai approve homepage` | Approves one named snapshot |
| `/testivai approve --all` | Approves every changed snapshot at once |

The action verifies write access, downloads the artifact, commits the updated baselines to your branch, and posts a confirmation comment. CI re-runs automatically.

## Test plan

- [ ] Open a PR with a visual change — `oss-visual` runs, posts diff comment
- [ ] Comment `/testivai approve --all` — `approve-baselines` runs, commits baselines, posts confirmation
- [ ] CI re-runs and passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)