### PR TITLE
docs: add two-lane comments to configs and test files

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,6 +1,25 @@
 import { defineConfig, devices } from '@playwright/test';
 
 /**
+ * ┌──────────────────────────────────────────────────────────────────────────┐
+ * │  CLOUD LANE  —  playwright.config.ts                                     │
+ * ├──────────────────────────────────────────────────────────────────────────┤
+ * │  Tests: tests/                                                           │
+ * │  Run:   npm test  (or: npx playwright test)                              │
+ * │                                                                          │
+ * │  Requires a TestivAI account + API key:                                  │
+ * │    export TESTIVAI_API_KEY=<your-key>                                    │
+ * │                                                                          │
+ * │  What you get with cloud:                                                │
+ * │    • REVEAL AI — 5-layer comparison (pixel, DOM, CSS, layout, AI)        │
+ * │    • Team dashboard, history, smart baselines                            │
+ * │    • Baseline approval workflow via testivai.io UI                       │
+ * │                                                                          │
+ * │  To switch to the OSS (no-account) lane instead:                        │
+ * │    npm run test:oss   →  uses playwright.oss.config.ts                   │
+ * │                          reads .testivai/baselines/, no API key needed   │
+ * └──────────────────────────────────────────────────────────────────────────┘
+ *
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({

--- a/playwright.oss.config.ts
+++ b/playwright.oss.config.ts
@@ -1,15 +1,32 @@
 /**
- * OSS lane Playwright config — local visual regression, no API key required.
- *
- * Reads baselines from `.testivai/baselines/` and writes an HTML report to
- * `visual-report/` after each run. Run with:
- *
- *   npm run test:oss
- *
- * To approve new/changed baselines after review:
- *   node -e "const {BaselineStore}=require('@testivai/witness/baselines');
- *            const s=new BaselineStore(process.cwd());
- *            s.listTemp().forEach(n=>s.approve(n))"
+ * ┌──────────────────────────────────────────────────────────────────────────┐
+ * │  OSS LANE  —  playwright.oss.config.ts                                   │
+ * ├──────────────────────────────────────────────────────────────────────────┤
+ * │  Tests: tests-oss/                                                       │
+ * │  Run:   npm run test:oss                                                 │
+ * │                                                                          │
+ * │  No API key or TestivAI account needed — runs fully offline.             │
+ * │  Baselines live in .testivai/baselines/ (committed to the repo).         │
+ * │  Report written to visual-report/index.html after every run.             │
+ * │                                                                          │
+ * │  What you get with OSS:                                                  │
+ * │    • Pixel diff  — detects any visual change                             │
+ * │    • DOM diff    — flags render noise when pixels change but DOM is same │
+ * │    • HTML report — results.json + index.html, uploadable as CI artifact  │
+ * │    • GitHub Action  mcbuddy/testivai-oss@v1 — PR comment + commit status │
+ * │                                                                          │
+ * │  To approve new/changed baselines after reviewing the report:           │
+ * │    node -e "                                                             │
+ * │      const {BaselineStore}=require('@testivai/witness/baselines');       │
+ * │      const s=new BaselineStore(process.cwd());                           │
+ * │      s.listTemp().forEach(n=>s.approve(n));                              │
+ * │    "                                                                     │
+ * │    Then commit and push the updated .testivai/baselines/ files.          │
+ * │                                                                          │
+ * │  To switch to the cloud lane instead:                                    │
+ * │    export TESTIVAI_API_KEY=<your-key>                                    │
+ * │    npm test   →  uses playwright.config.ts                               │
+ * └──────────────────────────────────────────────────────────────────────────┘
  */
 import { defineConfig, devices } from '@playwright/test';
 

--- a/testivai.config.ts
+++ b/testivai.config.ts
@@ -1,3 +1,14 @@
+/**
+ * ┌──────────────────────────────────────────────────────────────────────────┐
+ * │  CLOUD LANE CONFIG  —  testivai.config.ts                                │
+ * ├──────────────────────────────────────────────────────────────────────────┤
+ * │  This file configures the cloud comparison engine (REVEAL AI).           │
+ * │  It is read by playwright.config.ts / the cloud lane only.               │
+ * │                                                                          │
+ * │  The OSS lane (playwright.oss.config.ts) uses .testivai/config.json      │
+ * │  instead — see that file for OSS-specific settings (threshold, mode).    │
+ * └──────────────────────────────────────────────────────────────────────────┘
+ */
 export default {
   layout: {
     sensitivity: 2, // 0-4 scale (0=strict, 4=lenient)

--- a/tests-oss/oss-smoke.spec.ts
+++ b/tests-oss/oss-smoke.spec.ts
@@ -1,15 +1,22 @@
 /**
- * OSS Smoke Tests — visual regression with @testivai/witness-playwright
+ * OSS LANE — tests-oss/oss-smoke.spec.ts
  *
- * These tests run in local mode: no API key needed, no cloud account.
- * Baselines live in `.testivai/baselines/`; reports go to `visual-report/`.
+ * Runs with:  npm run test:oss  (uses playwright.oss.config.ts)
  *
- * First run  → all snapshots are "new" (baselines written)
+ * No API key or TestivAI account needed — runs fully offline.
+ * Baselines live in `.testivai/baselines/` (committed to the repo).
+ * Report written to visual-report/index.html after every run.
+ *
+ * What you get:
+ *   • Pixel diff  — detects any visual change
+ *   • DOM diff    — "DOM unchanged" = likely render noise, not a real change
+ *   • HTML report + CI artifact via mcbuddy/testivai-oss@v1
+ *
+ * First run  → all snapshots are "new" (baselines written to .testivai/baselines/)
  * Later runs → snapshots compared against baselines; diffs flagged in report
  *
- * The report also shows a DOM noise hint:
- *   • "DOM unchanged" → pixel diff is likely render noise (font hinting, AA)
- *   • "DOM changed"   → structural change detected; review carefully
+ * Looking for the cloud (REVEAL AI) lane? → tests/component-showcase.spec.ts
+ *   Run: export TESTIVAI_API_KEY=<your-key> && npm test
  */
 import { test, expect } from '@playwright/test';
 import { testivai } from '@testivai/witness-playwright';

--- a/tests/component-showcase.spec.ts
+++ b/tests/component-showcase.spec.ts
@@ -1,3 +1,20 @@
+/**
+ * CLOUD LANE — tests/component-showcase.spec.ts
+ *
+ * Runs with:  npm test  (uses playwright.config.ts)
+ *
+ * Requires:   export TESTIVAI_API_KEY=<your-key>
+ *             Without the key the reporter falls back to local mode
+ *             (same pixel diff as OSS, without cloud REVEAL AI features).
+ *
+ * Cloud features enabled with the key:
+ *   • REVEAL AI — 5-layer comparison (pixel, DOM, CSS, layout, AI)
+ *   • Team dashboard, run history, smart baselines
+ *   • Baseline approval via testivai.io UI
+ *
+ * Looking for the no-account lane? → tests-oss/oss-smoke.spec.ts
+ *   Run: npm run test:oss
+ */
 import { test, expect } from '@playwright/test';
 import { testivai } from '@testivai/witness-playwright';
 


### PR DESCRIPTION
Each config file and test file now has a clear header explaining:
- Which lane it belongs to (OSS or Cloud)
- How to run it (npm test vs npm run test:oss)
- What requirements it has (API key for cloud, none for OSS)
- Cross-reference to the other lane

Both lanes are preserved:
  tests/               → cloud lane (TESTIVAI_API_KEY required for REVEAL AI)
  tests-oss/           → OSS lane (no account, runs fully offline)
  playwright.config.ts → cloud config
  playwright.oss.config.ts → OSS config